### PR TITLE
Cp2kInput: improve add_keyword() and _add_keyword():

### DIFF
--- a/aiida_cp2k/calculations/__init__.py
+++ b/aiida_cp2k/calculations/__init__.py
@@ -90,11 +90,14 @@ class Cp2kCalculation(CalcJob):
         inp.add_keyword("GLOBAL/PROJECT", self._DEFAULT_PROJECT_NAME)
         if 'structure' in self.inputs:
             for i, letter in enumerate('ABC'):
-                inp.add_keyword('FORCE_EVAL/SUBSYS/CELL/' + letter,
-                                '{:<15} {:<15} {:<15}'.format(*self.inputs.structure.cell[i]))
+                inp.add_keyword(
+                    'FORCE_EVAL/SUBSYS/CELL/' + letter,
+                    '{:<15} {:<15} {:<15}'.format(*self.inputs.structure.cell[i]),
+                    override=False,
+                    conflicting_keys=['ABC', 'ALPHA_BETA_GAMMA', 'CELL_FILE_NAME'])
             topo = "FORCE_EVAL/SUBSYS/TOPOLOGY"
-            inp.add_keyword(topo + "/COORD_FILE_NAME", self._DEFAULT_COORDS_FILE_NAME)
-            inp.add_keyword(topo + "/COORD_FILE_FORMAT", "XYZ")
+            inp.add_keyword(topo + "/COORD_FILE_NAME", self._DEFAULT_COORDS_FILE_NAME, override=False)
+            inp.add_keyword(topo + "/COORD_FILE_FORMAT", "XYZ", override=False, conflicting_keys=['COORDINATE'])
 
         with io.open(folder.get_abs_path(self._DEFAULT_INPUT_FILE), mode="w", encoding="utf-8") as fobj:
             try:

--- a/aiida_cp2k/tests/test_input_generator.py
+++ b/aiida_cp2k/tests/test_input_generator.py
@@ -47,6 +47,92 @@ BAR boo
 &END BOO
 FOO bar""".format(inp=inp)
 
+    inp.add_keyword("BOO/BII", "bzzzzzz", override=False)
+    assert inp.render() == """{inp.DISCLAIMER}
+BAR boo
+&BOO
+   BAZ boo
+   BII boo
+&END BOO
+FOO bar""".format(inp=inp)
+
+    inp.add_keyword("BOO/BII/BCC", "bcr", override=False)
+    assert inp.render() == """{inp.DISCLAIMER}
+BAR boo
+&BOO
+   BAZ boo
+   BII boo
+&END BOO
+FOO bar""".format(inp=inp)
+
+    inp.add_keyword("BOO/BII/BCC", "bcr")
+    assert inp.render() == """{inp.DISCLAIMER}
+BAR boo
+&BOO
+   BAZ boo
+   &BII
+      BCC bcr
+   &END BII
+&END BOO
+FOO bar""".format(inp=inp)
+
+    inp.add_keyword("BOO/BII", "boo", override=False)
+    assert inp.render() == """{inp.DISCLAIMER}
+BAR boo
+&BOO
+   BAZ boo
+   &BII
+      BCC bcr
+   &END BII
+&END BOO
+FOO bar""".format(inp=inp)
+
+    inp.add_keyword("BOO/BII", "boo", override=True)
+    assert inp.render() == """{inp.DISCLAIMER}
+BAR boo
+&BOO
+   BAZ boo
+   BII boo
+&END BOO
+FOO bar""".format(inp=inp)
+
+    inp.add_keyword("BOO/BII", "boo", override=True)
+    assert inp.render() == """{inp.DISCLAIMER}
+BAR boo
+&BOO
+   BAZ boo
+   BII boo
+&END BOO
+FOO bar""".format(inp=inp)
+
+    inp.add_keyword("BOO/BIP", "bzz", override=False, conflicting_keys=['BII'])
+    assert inp.render() == """{inp.DISCLAIMER}
+BAR boo
+&BOO
+   BAZ boo
+   BII boo
+&END BOO
+FOO bar""".format(inp=inp)
+
+    inp.add_keyword("BOO/BIP", "bzz", override=False, conflicting_keys=[])
+    assert inp.render() == """{inp.DISCLAIMER}
+BAR boo
+&BOO
+   BAZ boo
+   BII boo
+   BIP bzz
+&END BOO
+FOO bar""".format(inp=inp)
+
+    inp.add_keyword("BOO/BEE", "bee", override=True, conflicting_keys=['BAZ', 'BII'])
+    assert inp.render() == """{inp.DISCLAIMER}
+BAR boo
+&BOO
+   BEE bee
+   BIP bzz
+&END BOO
+FOO bar""".format(inp=inp)
+
 
 def test_add_keyword_invariant_inp():
     """Check that the input dictionary is not modified by add_keyword()"""

--- a/aiida_cp2k/utils.py
+++ b/aiida_cp2k/utils.py
@@ -11,6 +11,10 @@ from __future__ import absolute_import
 from copy import deepcopy
 
 import six
+if six.PY2:
+    from collections import Mapping, Sequence
+else:
+    from collections.abc import Mapping, Sequence  # pylint: disable=import-error, no-name-in-module
 
 
 class Cp2kInput:  # pylint: disable=old-style-class
@@ -27,7 +31,10 @@ class Cp2kInput:  # pylint: disable=old-style-class
             # passed-in dictionary
             self._params = deepcopy(params)
 
-    def add_keyword(self, kwpath, value):
+    def __getitem__(self, key):
+        return self._params[key]
+
+    def add_keyword(self, kwpath, value, override=True, conflicting_keys=None):
         """
         Add a value for the given keyword.
 
@@ -35,12 +42,17 @@ class Cp2kInput:  # pylint: disable=old-style-class
             kwpath: Can be a single keyword, a path with `/` as divider for sections & key,
                     or a sequence with sections and key
             value: the value to set the given key to
+            override: whether to override the key if it is already present in the self._params
+            conflicting_keys: list of keys that cannot live together with the provided key
+                              (SOMETHING1/[..]/SOMETHING2/KEY). In case override is True, all conflicting keys will
+                              be removed, if override is False and conflicting_keys are present the new key won't be
+                              added.
         """
 
         if isinstance(kwpath, six.string_types):
             kwpath = kwpath.split("/")
 
-        Cp2kInput._add_keyword(kwpath, value, self._params)
+        Cp2kInput._add_keyword(kwpath, value, self._params, ovrd=override, cfct=conflicting_keys)
 
     def render(self):
         output = [self.DISCLAIMER]
@@ -48,17 +60,42 @@ class Cp2kInput:  # pylint: disable=old-style-class
         return u"\n".join(output)
 
     @staticmethod
-    def _add_keyword(kwpath, value, params):
-        """Add keyword in given nested dictionary"""
+    def _add_keyword(kwpath, value, params, ovrd, cfct):
+        """Add keyword into the given nested dictionary"""
+        conflicting_keys_present = []
+        # key/value for the deepest level
+        if len(kwpath) == 1:
+            if cfct:
+                conflicting_keys_present = [key for key in cfct if key in params]
+            if ovrd:  # if ovrd is True, set the new element's value and remove the conflicting keys
+                params[kwpath[0]] = value
+                for key in conflicting_keys_present:
+                    params.pop(key)
+            # if ovrd is False, I only add the new key if (1) it wasn't present beforeAND (2) it does not conflict
+            # with any key that is currently present
+            elif not conflicting_keys_present and kwpath[0] not in params:
+                params[kwpath[0]] = value
 
-        if len(kwpath) == 1:  # key/value for the current level
-            params[kwpath[0]] = value
-            return
-
-        if kwpath[0] not in params.keys():  # create an empty section if necessary
+        # the key was not present in the dictionary, and we are not yet at the deepest level,
+        # therefore a subdictionary should be added
+        elif kwpath[0] not in params:
             params[kwpath[0]] = {}
+            Cp2kInput._add_keyword(kwpath[1:], value, params[kwpath[0]], ovrd, cfct)
 
-        Cp2kInput._add_keyword(kwpath[1:], value, params[kwpath[0]])
+        # if it is a list, loop over its elements
+        elif isinstance(params[kwpath[0]], Sequence) and not isinstance(params[kwpath[0]], six.string_types):
+            for element in params[kwpath[0]]:
+                Cp2kInput._add_keyword(kwpath[1:], value, element, ovrd, cfct)
+
+        # if the key does NOT point to a dictionary and we are not yet at the deepest level,
+        # therefore, the element should be replaced with an empty dictionary unless ovrd is False
+        elif not isinstance(params[kwpath[0]], Mapping):
+            if ovrd:
+                params[kwpath[0]] = {}
+                Cp2kInput._add_keyword(kwpath[1:], value, params[kwpath[0]], ovrd, cfct)
+        # if params[kwpath[0]] points to a sub-dictionary, enter into it
+        else:
+            Cp2kInput._add_keyword(kwpath[1:], value, params[kwpath[0]], ovrd, cfct)
 
     @staticmethod
     def _render_section(output, params, indent=0):
@@ -93,10 +130,6 @@ class Cp2kInput:  # pylint: disable=old-style-class
                   &END KIND
         """
 
-        if six.PY2:
-            from collections import Mapping, Sequence
-        else:
-            from collections.abc import Mapping, Sequence  # pylint: disable=import-error, no-name-in-module
         for key, val in sorted(params.items()):
             # keys are not case-insensitive, ensure that they follow the current scheme
             if key.upper() != key:

--- a/setup.json
+++ b/setup.json
@@ -14,8 +14,9 @@
         "Development Status :: 4 - Beta"
     ],
     "install_requires": [
-        "aiida-core>=1.0.0b4",
-        "ase"
+        "aiida-core>=1.0.0b5",
+        "ase==3.17.0; python_version<'3.0'",
+        "ase; python_version>='3.5'"
     ],
     "entry_points": {
         "aiida.calculations": [

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -21,14 +21,15 @@ sudo service rabbitmq-server start
 verdi daemon start
 
 # run single calculation tests
-verdi run ./test_single_calculation/test_mm.py        cp2k@localhost
-verdi run ./test_single_calculation/test_dft.py       cp2k@localhost
-verdi run ./test_single_calculation/test_bands.py     cp2k@localhost
-verdi run ./test_single_calculation/test_geopt.py     cp2k@localhost
-verdi run ./test_single_calculation/test_no_struct.py cp2k@localhost
-verdi run ./test_single_calculation/test_restart.py   cp2k@localhost
-verdi run ./test_single_calculation/test_failure.py   cp2k@localhost
-verdi run ./test_single_calculation/test_precision.py cp2k@localhost
+verdi run ./test_single_calculation/test_mm.py                  cp2k@localhost
+verdi run ./test_single_calculation/test_dft.py                 cp2k@localhost
+verdi run ./test_single_calculation/test_multiple_force_eval.py cp2k@localhost
+verdi run ./test_single_calculation/test_bands.py               cp2k@localhost
+verdi run ./test_single_calculation/test_geopt.py               cp2k@localhost
+verdi run ./test_single_calculation/test_no_struct.py           cp2k@localhost
+verdi run ./test_single_calculation/test_restart.py             cp2k@localhost
+verdi run ./test_single_calculation/test_failure.py             cp2k@localhost
+verdi run ./test_single_calculation/test_precision.py           cp2k@localhost
 
 #  run workflows
 

--- a/test/test_single_calculation/test_multiple_force_eval.py
+++ b/test/test_single_calculation/test_multiple_force_eval.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=invalid-name
+###############################################################################
+# Copyright (c), The AiiDA-CP2K authors.                                      #
+# SPDX-License-Identifier: MIT                                                #
+# AiiDA-CP2K is hosted on GitHub at https://github.com/aiidateam/aiida-cp2k   #
+# For further information on the license, see the LICENSE.txt file.           #
+###############################################################################
+"""Run simple DFT calculation"""
+
+from __future__ import print_function
+from __future__ import absolute_import
+
+import sys
+import ase
+
+from aiida.engine import run
+from aiida.orm import (Code, Dict, StructureData)
+from aiida.common import NotExistent
+from aiida_cp2k.calculations import Cp2kCalculation
+
+# =============================================================================
+if len(sys.argv) != 2:
+    print("Usage: test_dft.py <code_name>")
+    sys.exit(1)
+
+codename = sys.argv[1]
+try:
+    code = Code.get_from_string(codename)
+except NotExistent:
+    print("The code '{}' does not exist".format(codename))
+    sys.exit(1)
+
+print("Testing CP2K ENERGY on H2O dimer (Mixed: DFT+MM)...")
+
+# structure
+pos = [[0.934, 2.445, 1.844], [1.882, 2.227, 1.982], [0.81, 3.165, 2.479], [3.59, 2.048, 2.436], [4.352, 2.339, 1.906],
+       [3.953, 1.304, 2.946]]
+atoms = ase.Atoms(symbols='OH2OH2', pbc=True, cell=[5.0, 5.0, 5.0])
+atoms.set_positions(pos)
+structure = StructureData(ase=atoms)
+
+# parameters
+parameters = Dict(
+    dict={
+        'MULTIPLE_FORCE_EVALS': {
+            'FORCE_EVAL_ORDER': '2 3',
+            'MULTIPLE_SUBSYS': 'T',
+        },
+        'FORCE_EVAL': [
+            {
+                'METHOD': 'MIXED',
+                'MIXED': {
+                    'MIXING_TYPE': 'GENMIX',
+                    'GENERIC': {
+                        'ERROR_LIMIT': 1.0E-10,
+                        'MIXING_FUNCTION': 'E1+E2',
+                        'VARIABLES': 'E1 E2',
+                    },
+                    'MAPPING': {
+                        'FORCE_EVAL_MIXED': {
+                            'FRAGMENT': [
+                                {
+                                    '_': 1,
+                                    '1': '3'
+                                },
+                                {
+                                    '_': 2,
+                                    '4': '6'
+                                },
+                            ],
+                        },
+                        'FORCE_EVAL': [{
+                            '_': 1,
+                            'DEFINE_FRAGMENTS': '1 2',
+                        }, {
+                            '_': 2,
+                            'DEFINE_FRAGMENTS': '1 2',
+                        }],
+                    }
+                },
+            },
+            {
+                'METHOD': 'FIST',
+                'MM': {
+                    'FORCEFIELD': {
+                        'SPLINE': {
+                            'EPS_SPLINE': 1.30E-5,
+                            'EMAX_SPLINE': 0.8,
+                        },
+                        'CHARGE': [
+                            {
+                                'ATOM': 'H',
+                                'CHARGE': 0.0,
+                            },
+                            {
+                                'ATOM': 'O',
+                                'CHARGE': 0.0,
+                            },
+                        ],
+                        'BOND': {
+                            'ATOMS': 'H O',
+                            'K': 0.0,
+                            'R0': 2.0,
+                        },
+                        'BEND': {
+                            'ATOMS': 'H O H',
+                            'K': 0.0,
+                            'THETA0': 2.0,
+                        },
+                        'NONBONDED': {
+                            'LENNARD-JONES': [
+                                {
+                                    'ATOMS': 'H H',
+                                    'EPSILON': 0.2,
+                                    'SIGMA': 2.4,
+                                },
+                                {
+                                    'ATOMS': 'H O',
+                                    'EPSILON': 0.4,
+                                    'SIGMA': 3.0,
+                                },
+                                {
+                                    'ATOMS': 'O O',
+                                    'EPSILON': 0.8,
+                                    'SIGMA': 3.6,
+                                },
+                            ]
+                        },
+                    },
+                    'POISSON': {
+                        'EWALD': {
+                            'EWALD_TYPE': 'none',
+                        }
+                    }
+                },
+                'SUBSYS': {
+                    'TOPOLOGY': {
+                        'CONNECTIVITY': 'GENERATE',
+                        'GENERATE': {
+                            'CREATE_MOLECULES': True,
+                        }
+                    }
+                }
+            },
+            {
+                'METHOD': 'Quickstep',
+                'DFT': {
+                    'BASIS_SET_FILE_NAME': 'BASIS_MOLOPT',
+                    'QS': {
+                        'EPS_DEFAULT': 1.0e-12,
+                        'WF_INTERPOLATION': 'ps',
+                        'EXTRAPOLATION_ORDER': 3,
+                    },
+                    'MGRID': {
+                        'NGRIDS': 4,
+                        'CUTOFF': 280,
+                        'REL_CUTOFF': 30,
+                    },
+                    'XC': {
+                        'XC_FUNCTIONAL': {
+                            '_': 'LDA',
+                        },
+                    },
+                    'POISSON': {
+                        'PERIODIC': 'none',
+                        'PSOLVER': 'MT',
+                    },
+                },
+                'SUBSYS': {
+                    'KIND': [
+                        {
+                            '_': 'O',
+                            'BASIS_SET': 'DZVP-MOLOPT-SR-GTH',
+                            'POTENTIAL': 'GTH-LDA-q6'
+                        },
+                        {
+                            '_': 'H',
+                            'BASIS_SET': 'DZVP-MOLOPT-SR-GTH',
+                            'POTENTIAL': 'GTH-LDA-q1'
+                        },
+                    ],
+                },
+            },
+        ]
+    })
+
+options = {
+    "resources": {
+        "num_machines": 1,
+        "num_mpiprocs_per_machine": 1,
+    },
+    "max_wallclock_seconds": 1 * 3 * 60,
+}
+inputs = {
+    'structure': structure,
+    'parameters': parameters,
+    'code': code,
+    'metadata': {
+        'options': options,
+    }
+}
+
+print("Submitted calculation...")
+run(Cp2kCalculation, **inputs)


### PR DESCRIPTION
fixes #20 
1) Add two arguments:
  override: whether to override the key if it is already present
  conflicting_keys: list of keys that cannot live together with the
                    provided key.
2) Modify the behavior of the functions to properly handle them
3) Add tests
4) Cp2kCalculation.prepare_for_submission(): only override the unit cell
in parameters if it is not present.