### PR TITLE
Do not specify input_filename and output_filename in metadata

### DIFF
--- a/aiida_cp2k/calculations/__init__.py
+++ b/aiida_cp2k/calculations/__init__.py
@@ -50,15 +50,7 @@ class Cp2kCalculation(CalcJob):
                              help='additional input files',
                              dynamic=True)
 
-        # Default file names, parser, etc..
-        spec.input('metadata.options.input_filename',
-                   valid_type=six.string_types,
-                   default=cls._DEFAULT_INPUT_FILE,
-                   non_db=True)
-        spec.input('metadata.options.output_filename',
-                   valid_type=six.string_types,
-                   default=cls._DEFAULT_OUTPUT_FILE,
-                   non_db=True)
+        # Specify default parser
         spec.input('metadata.options.parser_name',
                    valid_type=six.string_types,
                    default=cls._DEFAULT_PARSER,


### PR DESCRIPTION
fixes #21
We do not allow users to modify the default values for the input and
output files. This commit does not modify plugin's functionality,
but removes the confusion discussed in #21.