### PR TITLE
fix an issue with writing coordinates

### DIFF
--- a/aiida_cp2k/calculations/__init__.py
+++ b/aiida_cp2k/calculations/__init__.py
@@ -164,7 +164,7 @@ class Cp2kCalculation(CalcJob):
         s_ase = structure.get_ase()
         elem_tags = ['' if t == 0 else str(t) for t in s_ase.get_tags()]
         elem_symbols = list(map(add, s_ase.get_chemical_symbols(), elem_tags))
-        elem_coords = ['{:20.16f} {:20.16f} {:20.16f}'.format(p[0], p[1], p[2]) for p in s_ase.get_positions()]
+        elem_coords = ['{:25.16f} {:25.16f} {:25.16f}'.format(p[0], p[1], p[2]) for p in s_ase.get_positions()]
         with io.open(folder.get_abs_path(name), mode="w", encoding="utf-8") as fobj:
             fobj.write(u'{}\n\n'.format(len(elem_coords)))
             fobj.write(u'\n'.join(map(add, elem_symbols, elem_coords)))


### PR DESCRIPTION
There has been an issue in writing `aiida.coord.xyz` file for some of structures where the `x` coordinate contains negative sign and two digits before decimal point which would cause `x` coordinate to be glued to the symbol like:
```
C4-17.2206645768000008  30.9491904397659994   7.4741380992000002
```
This PR fixes that issue.