### PR TITLE
Remove warnings check in the tests

### DIFF
--- a/examples/single_calculations/example_mm.py
+++ b/examples/single_calculations/example_mm.py
@@ -121,9 +121,6 @@ def example_mm(cp2k_code):
     print("Submitted calculation...")
     calc = run(builder)
 
-    # check warnings
-    assert calc['output_parameters'].dict.nwarnings == 0
-
     # check energy
     expected_energy = 0.146927412614e-3
     if abs(calc['output_parameters'].dict.energy - expected_energy) < 1e-10:

--- a/examples/single_calculations/example_restart.py
+++ b/examples/single_calculations/example_restart.py
@@ -165,9 +165,6 @@ def example_restart(cp2k_code):
     if abs(calc2['output_parameters'].dict.energy - expected_energy) < 1e-10:
         print("OK, energy has the expected value")
 
-    # if restart wfn is not found it will create a warning
-    assert calc2['output_parameters'].dict.nwarnings == 1
-
     # ensure that this warning originates from overwritting coordinates
     output = calc2['retrieved']._repository.get_object_content('aiida.out')  # pylint: disable=protected-access
     assert re.search("WARNING .* :: Overwriting coordinates", output)


### PR DESCRIPTION
fixes #71 
As CP2K code doesn't have a well defined policy on the usage
of warnings - it is better to not check for them.