### PR TITLE
enable dynamic output

### DIFF
--- a/aiida_cp2k/calculations/__init__.py
+++ b/aiida_cp2k/calculations/__init__.py
@@ -87,7 +87,7 @@ class Cp2kCalculation(CalcJob):
         spec.output('output_structure', valid_type=StructureData, required=False, help='optional relaxed structure')
         spec.output('output_bands', valid_type=BandsData, required=False, help='optional band structure')
         spec.default_output_node = 'output_parameters'
-        
+
         spec.outputs.dynamic = True
 
     def prepare_for_submission(self, folder):

--- a/aiida_cp2k/calculations/__init__.py
+++ b/aiida_cp2k/calculations/__init__.py
@@ -87,6 +87,8 @@ class Cp2kCalculation(CalcJob):
         spec.output('output_structure', valid_type=StructureData, required=False, help='optional relaxed structure')
         spec.output('output_bands', valid_type=BandsData, required=False, help='optional band structure')
         spec.default_output_node = 'output_parameters'
+        
+        spec.outputs.dynamic = True
 
     def prepare_for_submission(self, folder):
         """Create the input files from the input nodes passed to this instance of the `CalcJob`.


### PR DESCRIPTION
Enable dynamic output so that custom parsers can create extra output nodes. (e.g. a StructureData for each converged NEB replica geometry.)