### PR TITLE
Conftest: change cp2k executable name

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,4 +7,4 @@ pytest_plugins = ['aiida.manage.tests.pytest_fixtures']  # pylint: disable=inval
 
 @pytest.fixture(scope='function')
 def cp2k_code(aiida_local_code_factory):  # pylint: disable=unused-argument
-    return aiida_local_code_factory("cp2k", "cp2k.popt")
+    return aiida_local_code_factory("cp2k", "cp2k")


### PR DESCRIPTION
Replace executable name from 'cp2k.popt' to 'cp2k' which is more
general.