### PR TITLE
Advanced parser 'Total energy'

### DIFF
--- a/aiida_cp2k/utils/parser.py
+++ b/aiida_cp2k/utils/parser.py
@@ -46,6 +46,11 @@ def parse_cp2k_output_advanced(fstring):  # pylint: disable=too-many-locals, too
             energy = float(line.split()[8])
             result_dict['energy'] = energy
             result_dict['energy_units'] = "a.u."
+        if line.strip().startswith('Total energy: '):
+            # In case of constrained geo opt, "ENERGY| ..." also contains the constraint energy
+            # This only contains the electronic SCF energy
+            energy_scf = float(line.split()[2])
+            result_dict['energy_scf'] = energy_scf
         if 'The number of warnings for this run is' in line:
             result_dict['nwarnings'] = int(line.split()[-1])
         if 'exceeded requested execution time' in line:


### PR DESCRIPTION
Hi! When doing constrained geometry optimizations, the parsed total energy on line "ENERGY| FORCE_EVAL ..." contains the electronic energy and the constraint energy. We would also need the just the electronic energy parsed, that's written on line "Total energy: ...".

example output for constrained optimization of H2:

![Annotation 2020-08-20 153852](https://user-images.githubusercontent.com/8721264/90777131-4b869000-e2fb-11ea-889c-2d062cfaa06a.png)

I also included the input and output scripts of the calculation.
[aiida.out.txt](https://github.com/aiidateam/aiida-cp2k/files/5103431/aiida.out.txt)
[aiida.inp.txt](https://github.com/aiidateam/aiida-cp2k/files/5103432/aiida.inp.txt)


