### PR TITLE
Fix resubmit_unconverged_geometry handler.

### DIFF
--- a/aiida_cp2k/workchains/base.py
+++ b/aiida_cp2k/workchains/base.py
@@ -74,7 +74,7 @@ class Cp2kBaseWorkChain(BaseRestartWorkChain):
                     params = add_restart_sections(params)
 
             # If not all the restart keys are present, adding them to the input dictionary
-            except KeyError:
+            except (AttributeError, KeyError):
                 params = add_restart_sections(params)
 
             # Might be able to solve the problem


### PR DESCRIPTION
fixes #115 

Currently, an AiiDA Dict object defined as follows:
```
d = Dict(dict={'a':{'b':1}})
```
Returns two type of errors if the key isn't present:
- `d['x']` returns AttributeError
- `d['a']['x'] returns KeyError

This PR adapts the handler for this behaviour.