### PR TITLE
Advanced parser: integr. spin dens and S-square

### DIFF
--- a/aiida_cp2k/utils/parser.py
+++ b/aiida_cp2k/utils/parser.py
@@ -75,6 +75,19 @@ def parse_cp2k_output_advanced(fstring):  # pylint: disable=too-many-locals, too
         if line.startswith(' DFT| ') and 'dft_type' not in result_dict.keys():
             result_dict['dft_type'] = line.split()[-1]  # RKS, UKS or ROKS
 
+        if line.strip().startswith("Integrated absolute spin density"):
+            if 'integrated_abs_spin_dens' not in result_dict:
+                result_dict['integrated_abs_spin_dens'] = []
+            result_dict['integrated_abs_spin_dens'].append(float(line.split()[-1]))
+
+        if line.strip().startswith("Ideal and single determinant"):
+            s2_ideal, s2_expect = line.split()[-2:]
+            if 'spin_square_ideal' not in result_dict:
+                result_dict['spin_square_ideal'] = s2_ideal
+            if 'spin_square_expectation' not in result_dict:
+                result_dict['spin_square_expectation'] = []
+            result_dict['spin_square_expectation'].append(s2_expect)
+
         # read the number of electrons in the first scf (NOTE: it may change but it is not updated!)
         if re.search('Number of electrons: ', line):
             if 'init_nel_spin1' not in result_dict.keys():

--- a/aiida_cp2k/utils/parser.py
+++ b/aiida_cp2k/utils/parser.py
@@ -83,10 +83,10 @@ def parse_cp2k_output_advanced(fstring):  # pylint: disable=too-many-locals, too
         if line.strip().startswith("Ideal and single determinant"):
             s2_ideal, s2_expect = line.split()[-2:]
             if 'spin_square_ideal' not in result_dict:
-                result_dict['spin_square_ideal'] = s2_ideal
+                result_dict['spin_square_ideal'] = float(s2_ideal)
             if 'spin_square_expectation' not in result_dict:
                 result_dict['spin_square_expectation'] = []
-            result_dict['spin_square_expectation'].append(s2_expect)
+            result_dict['spin_square_expectation'].append(float(s2_expect))
 
         # read the number of electrons in the first scf (NOTE: it may change but it is not updated!)
         if re.search('Number of electrons: ', line):


### PR DESCRIPTION
Hi! For UKS calculations, this will parse the integrated absolute spin density and S^2 ideal and expectation value. Because the integrated abs spin density and S^2 are printed out after each SCF (and therefore multiple times e.g. in a geometry opt.), I stored them in a list.