### PR TITLE
Cp2kBaseWorkChain modifications.

### DIFF
--- a/aiida_cp2k/workchains/base.py
+++ b/aiida_cp2k/workchains/base.py
@@ -3,6 +3,7 @@
 
 from aiida.common import AttributeDict
 from aiida.engine import BaseRestartWorkChain, ExitCode, ProcessHandlerReport, process_handler, while_
+from aiida.orm import Dict
 from aiida.plugins import CalculationFactory
 
 from ..utils import add_restart_sections
@@ -31,6 +32,8 @@ class Cp2kBaseWorkChain(BaseRestartWorkChain):
         )
 
         spec.expose_outputs(Cp2kCalculation)
+        spec.output('final_input_parameters', valid_type=Dict, required=False,
+            help='The input parameters used for the final calculation.')
 
     def setup(self):
         """Call the `setup` of the `BaseRestartWorkChain` and then create the inputs dictionary in `self.ctx.inputs`.
@@ -41,6 +44,12 @@ class Cp2kBaseWorkChain(BaseRestartWorkChain):
 
         super(Cp2kBaseWorkChain, self).setup()
         self.ctx.inputs = AttributeDict(self.exposed_inputs(Cp2kCalculation, 'cp2k'))
+
+    def results(self):
+        super().results()
+        if self.inputs.cp2k.parameters != self.ctx.inputs.parameters:
+            self.out('final_input_parameters', self.ctx.inputs.parameters)
+
 
 
     @process_handler(priority=400, enabled=False)

--- a/examples/workchains/example_base_restart.py
+++ b/examples/workchains/example_base_restart.py
@@ -115,7 +115,13 @@ def example_base(cp2k_code):
     builder.cp2k.metadata.options.max_wallclock_seconds = 1 * 3 * 60
 
     print("Submitted calculation...")
-    run(builder)
+    calc = run(builder)
+
+    if 'EXT_RESTART' in calc['final_input_parameters'].dict:
+        print("OK, EXT_RESTART section is present in the final_input_parameters.")
+    else:
+        print("ERROR, EXT_RESTART section is NOT present in the final_input_parameters.")
+        sys.exit(3)
 
 
 @click.command('cli')


### PR DESCRIPTION
Store the input dictionary used for the last calculation as
'final_input_parameters' output node. Useful for the restarts.