### PR TITLE
bump pytest version to 6

### DIFF
--- a/examples/single_calculations/example_mm.py
+++ b/examples/single_calculations/example_mm.py
@@ -130,7 +130,7 @@ def example_mm(cp2k_code):
         sys.exit(3)
 
     # Check if callgraph is there.
-    if "runtime.callgraph" in calc['retrieved']._repository.list_object_names():  # pylint: disable=protected-access
+    if "runtime.callgraph" in calc['retrieved'].list_object_names():
         print("OK, callgraph file was retrived.")
     else:
         print("ERROR!")

--- a/setup.json
+++ b/setup.json
@@ -32,9 +32,9 @@
     },
     "extras_require": {
         "test": [
-            "pgtest==1.2.0",
-            "pytest>=4.4,<5.0.0",
-            "pytest-cov>=2.6.1,<3.0.0",
+            "pgtest~=1.3",
+            "pytest~=6.0",
+            "pytest-cov~=2.11.1",
             "coverage"
         ],
         "pre-commit":[


### PR DESCRIPTION
pytest <6 does not support reading the pyproject.toml.

This reinstates running of the examples as part of the test suite.