### PR TITLE
`Cp2kBaseWorkChain`: Fix restart for no `output_structure`

### DIFF
--- a/aiida_cp2k/workchains/base.py
+++ b/aiida_cp2k/workchains/base.py
@@ -42,7 +42,6 @@ class Cp2kBaseWorkChain(BaseRestartWorkChain):
         This `self.ctx.inputs` dictionary will be used by the `BaseRestartWorkChain` to submit the calculations in the
         internal loop.
         """
-
         super(Cp2kBaseWorkChain, self).setup()
         self.ctx.inputs = AttributeDict(self.exposed_inputs(Cp2kCalculation, 'cp2k'))
 
@@ -50,8 +49,10 @@ class Cp2kBaseWorkChain(BaseRestartWorkChain):
         super().results()
         if self.inputs.cp2k.parameters != self.ctx.inputs.parameters:
             self.out('final_input_parameters', self.ctx.inputs.parameters)
+
     def overwrite_input_structure(self):
-        self.ctx.inputs.structure = self.ctx.children[self.ctx.iteration-1].outputs.output_structure
+        if "output_structure" in self.ctx.children[self.ctx.iteration-1].outputs:
+            self.ctx.inputs.structure = self.ctx.children[self.ctx.iteration-1].outputs.output_structure
 
     @process_handler(priority=400, enabled=False)
     def resubmit_unconverged_geometry(self, calc):


### PR DESCRIPTION
For some CP2K calculations, e.g. a "single-point" calculation, there is
no `output_structure` output in the `Cp2kCalculation`. In this case the
current `Cp2KBaseWorkChain` fails to restart, since the
`overwrite_input_structure` step in the outline _expects_ this output to
be present.

Here we simply add a check to see if `output_structure` is one of the
outputs of the final `Cp2kCalculation`, and only update the input
structure in the context if that is the case.