### PR TITLE
BaseRestartWorkChain: `remove resubmit_unconverged_geometry` handler.

### DIFF
--- a/aiida_cp2k/utils/__init__.py
+++ b/aiida_cp2k/utils/__init__.py
@@ -6,12 +6,7 @@
 ###############################################################################
 """AiiDA-CP2K utils"""
 
-from .input_generator import (
-    Cp2kInput,
-    add_ext_restart_section,
-    add_restart_sections,
-    add_wfn_restart_section,
-)
+from .input_generator import Cp2kInput, add_ext_restart_section, add_wfn_restart_section
 from .parser import parse_cp2k_output, parse_cp2k_output_advanced, parse_cp2k_trajectory
 from .workchains import (
     HARTREE2EV,
@@ -28,7 +23,6 @@ from .workchains import (
 __all__ = [
     "Cp2kInput",
     "add_ext_restart_section",
-    "add_restart_sections",
     "add_wfn_restart_section",
     "parse_cp2k_output",
     "parse_cp2k_output_advanced",

--- a/aiida_cp2k/utils/input_generator.py
+++ b/aiida_cp2k/utils/input_generator.py
@@ -184,28 +184,6 @@ class Cp2kInput:
 
 
 @calcfunction
-def add_restart_sections(input_dict):
-    """Add restart section to the input dictionary."""
-
-    params = input_dict.get_dict()
-    restart_wfn_dict = {
-        "FORCE_EVAL": {
-            "DFT": {
-                "RESTART_FILE_NAME": "./parent_calc/aiida-RESTART.wfn",
-                "SCF": {
-                    "SCF_GUESS": "RESTART",
-                },
-            },
-        },
-    }
-    merge_dict(params, restart_wfn_dict)
-
-    # overwrite the complete EXT_RESTART section if present
-    params["EXT_RESTART"] = {"RESTART_FILE_NAME": "./parent_calc/aiida-1.restart"}
-    return Dict(params)
-
-
-@calcfunction
 def add_wfn_restart_section(input_dict, is_kpoints):
     """Add wavefunction restart section to the input dictionary."""
     params = input_dict.get_dict()

--- a/aiida_cp2k/workchains/base.py
+++ b/aiida_cp2k/workchains/base.py
@@ -3,7 +3,6 @@
 from aiida.common import AttributeDict
 from aiida.engine import (
     BaseRestartWorkChain,
-    ExitCode,
     ProcessHandlerReport,
     process_handler,
     while_,
@@ -11,16 +10,11 @@ from aiida.engine import (
 from aiida.orm import Bool, Dict
 from aiida.plugins import CalculationFactory
 
-from ..utils import (
-    add_ext_restart_section,
-    add_restart_sections,
-    add_wfn_restart_section,
-)
+from ..utils import add_ext_restart_section, add_wfn_restart_section
 
 Cp2kCalculation = CalculationFactory('cp2k')  # pylint: disable=invalid-name
 
 
-# +
 class Cp2kBaseWorkChain(BaseRestartWorkChain):
     """Workchain to run a CP2K calculation with automated error handling and restarts."""
 
@@ -68,52 +62,6 @@ class Cp2kBaseWorkChain(BaseRestartWorkChain):
     def overwrite_input_structure(self):
         if "output_structure" in self.ctx.children[self.ctx.iteration-1].outputs:
             self.ctx.inputs.structure = self.ctx.children[self.ctx.iteration-1].outputs.output_structure
-
-    @process_handler(priority=400, enabled=False)
-    def resubmit_unconverged_geometry(self, calc):
-        """
-        Deprecated!
-
-        Please use `restart_incomplete_calculation` handler instead.
-        This hanlder will be removed in the version 2.0 of the plugin.
-        """
-
-        self.report("Checking the geometry convergence.")
-
-        content_string = calc.outputs.retrieved.get_object_content(calc.get_attribute('output_filename'))
-
-        calc_finished = "PROGRAM ENDED AT"
-        time_exceeded = "exceeded requested execution time"
-        one_step_done = "Max. gradient              ="
-        self.ctx.inputs.parent_calc_folder = calc.outputs.remote_folder
-        params = self.ctx.inputs.parameters
-
-        # If the problem is recoverable then do restart
-        if (calc_finished not in content_string or time_exceeded in content_string) and one_step_done in content_string:  # pylint: disable=line-too-long
-            params = add_restart_sections(params)
-
-            # Might be able to solve the problem
-            self.ctx.inputs.parameters = params  # params (new or old ones) that for sure
-            # include the necessary restart key-value pairs
-            self.report(
-                "The CP2K calculation wasn't completed. The restart of the calculation might be able to "
-                "fix the problem.")
-            return ProcessHandlerReport(False)
-
-        # If the problem is not recoverable
-        if (calc_finished not in content_string or
-                time_exceeded in content_string) and one_step_done not in content_string:
-
-            self.report("It seems that the restart of CP2K calculation wouldn't be able to fix the problem as the "
-                        "geometry optimization couldn't complete a single step. Sending a signal to stop the Base "
-                        "work chain.")
-
-            # Signaling to the base work chain that the problem could not be recovered.
-            return ProcessHandlerReport(True, ExitCode(1))
-
-        self.report("The geometry seem to be converged.")
-        # If everything is alright
-        return None
 
     @process_handler(priority=401, exit_codes=[
         Cp2kCalculation.exit_codes.ERROR_OUT_OF_WALLTIME,


### PR DESCRIPTION
fixes #175 
* The handler is substituted by the `restart_incomplete_calculation` handler.
* Also, remove the `add_restart_sections` function as it was only used by the
`resubmit_unconverged_geometry ` handler.