### PR TITLE
Update tests to new aiida's fixtures.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,11 +11,9 @@ def cp2k_code(aiida_local_code_factory):  # pylint: disable=unused-argument
     return aiida_local_code_factory("cp2k", "cp2k")
 
 
-@pytest.fixture(scope="function")
-def clear_database(aiida_profile):
-    """Clear the database after a test with this fixture"""
-    yield
-    aiida_profile.reset_db()
+@pytest.fixture(scope="function", autouse=True)
+def clear_database(aiida_profile_clean):
+    """Automatically clear database in between tests."""
 
 
 # from https://stackoverflow.com/a/25188424

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -360,4 +360,5 @@ nitpick_ignore = [
     ("py:class", "utils.AttributesFrozendict"),
     ("py:class", "State"),
     ("py:class", "Stepper"),
+    ("py:class", "CalcJobNode"),
 ]


### PR DESCRIPTION
fixes #180

Replace the deprecated `clear_database` fixture with `aiida_profile_clean`.