### PR TITLE
bug fix due to aiida-core version

### DIFF
--- a/aiida_cp2k/workchains/base.py
+++ b/aiida_cp2k/workchains/base.py
@@ -65,7 +65,7 @@ class Cp2kBaseWorkChain(engine.BaseRestartWorkChain):
         trajectories = self._collect_all_trajetories()
         if trajectories:
             self.report("Work chain completed successfully, collecting all trajectories")
-            if self.ctx.inputs.parameters.get("GLOBAL", {}).get("RUN_TYPE") == "GEO_OPT":
+            if self.ctx.inputs.parameters.get_dict().get("GLOBAL", {}).get("RUN_TYPE") == "GEO_OPT":
                 output_trajectory = utils.merge_trajectory_data_non_unique(*trajectories)
             else:
                 output_trajectory = utils.merge_trajectory_data_unique(*trajectories)


### PR DESCRIPTION
if self.ctx.inputs.parameters.get_dict().get("GLOBAL", {}).get("RUN_TYPE") == "GEO_OPT":

here .get_dict() is needed. I guess it can be dropped in later versions of aiida-core