### PR TITLE
added sorting of trajectories according to stepid

### DIFF
--- a/aiida_cp2k/utils/datatype_helpers.py
+++ b/aiida_cp2k/utils/datatype_helpers.py
@@ -433,11 +433,22 @@ def _merge_trajectories_into_dictionary(*trajectories, unique_stepids=False):
             [traj.get_array(array_name) for traj in trajectories], axis=0
         )
         final_trajectory_dict[array_name] = merged_array
-
+        
+    # reorder arrays to have the same order as in the original whole trajectory
+    try:
+        stepids = final_trajectory_dict["stepids"]
+    except KeyError:
+        stepids = np.concatenate([traj.get_stepids() for traj in trajectories], axis=0)
+    sorted_indices = np.argsort(stepids)
+    for array_name in array_names:
+        final_trajectory_dict[array_name] = final_trajectory_dict[array_name][
+            sorted_indices
+        ]
+    
     # If unique_stepids is True, we only keep the unique stepids.
     # The other arrays are then also reduced to the unique stepids.
     if unique_stepids:
-        stepids = np.concatenate([traj.get_stepids() for traj in trajectories], axis=0)
+        #stepids = np.concatenate([traj.get_stepids() for traj in trajectories], axis=0)
         final_trajectory_dict["stepids"], unique_indices = np.unique(
             stepids, return_index=True
         )


### PR DESCRIPTION
It was tested with geometry optimisation workcahin and with reftraj workchain.
Make sure that if we are merging fragments of a trajectory the original order (e.g. of an input trajectory in reftraj) is preserved