### PR TITLE
Make cp2k-output-tools optional

### DIFF
--- a/aiida_cp2k/parsers/__init__.py
+++ b/aiida_cp2k/parsers/__init__.py
@@ -13,6 +13,7 @@ import numpy as np
 from aiida import common, engine, orm, parsers, plugins
 
 from .. import utils
+from ..utils.xyz import parse as parse_xyz
 
 StructureData = plugins.DataFactory("core.structure")
 BandsData = plugins.DataFactory("core.array.bands")
@@ -154,12 +155,10 @@ class Cp2kBaseParser(parsers.Parser):
         except OSError:
             return self.exit_codes.ERROR_COORDINATES_TRAJECTORY_READ
 
-        from cp2k_output_tools.trajectories.xyz import parse
-
         positions_traj = []
         stepids_traj = []
         energies_traj = []
-        for frame in parse(output_xyz_pos):
+        for frame in parse_xyz(output_xyz_pos):
             _, positions = zip(*frame["atoms"])
             positions_traj.append(positions)
             comment_split = frame["comment"].split(",")
@@ -196,7 +195,7 @@ class Cp2kBaseParser(parsers.Parser):
                     forces_traj_fname
                 )
                 forces_traj = []
-                for frame in parse(output_forces):
+                for frame in parse_xyz(output_forces):
                     _, forces = zip(*frame["atoms"])
                     forces_traj.append(forces)
                 forces_traj = np.array(forces_traj)
@@ -279,7 +278,13 @@ class Cp2kToolsParser(Cp2kBaseParser):
     def _parse_stdout(self):
         """Very advanced CP2K output file parser."""
 
-        from cp2k_output_tools import parse_iter
+        try:
+            from cp2k_output_tools import parse_iter
+        except ImportError as exception:
+            raise ImportError(
+                "Cp2kToolsParser requires the optional cp2k-output-tools "
+                "dependency. Install aiida-cp2k[output-tools] to use this parser."
+            ) from exception
 
         # Read the standard output of CP2K.
         exit_code, output_string = self._read_stdout()

--- a/aiida_cp2k/utils/xyz.py
+++ b/aiida_cp2k/utils/xyz.py
@@ -1,0 +1,142 @@
+###############################################################################
+# Copyright (c), Tiziano Müller.                                             #
+# SPDX-License-Identifier: MIT                                                #
+#                                                                             #
+# Adapted from cp2k-output-tools commit                                       #
+# 403cc70966d7284d9f71f56b8cd2ae08f969fa62.                                  #
+###############################################################################
+"""Parse CP2K XYZ trajectory files."""
+
+import contextlib
+import mmap
+import re
+from collections.abc import Iterator
+
+__all__ = ["parse", "parse_iter", "BlockIterator"]
+
+
+@contextlib.contextmanager
+def as_byteorstringlike(fh_or_content):
+    """Yield content and whether it is a Unicode string."""
+
+    if isinstance(fh_or_content, str):
+        yield fh_or_content, True
+    elif isinstance(fh_or_content, bytes):
+        yield fh_or_content, False
+    else:
+        mmapped = mmap.mmap(fh_or_content.fileno(), 0, access=mmap.ACCESS_READ)
+
+        try:
+            yield mmapped, False
+        finally:
+            mmapped.close()
+
+
+# MULTILINE and VERBOSE regex to match coordinate lines in a frame:
+POS_MATCH_REGEX = r"""
+^                                                               # Linestart
+[ \t]*                                                          # Optional white space
+(?P<sym>[A-Za-z]+[A-Za-z0-9]*)\s+                               # get the symbol
+(?P<x> [\-\+]? (\d*\.\d+|\d+\.?\d*) ([Ee][\+\-]?\d+)? ) [ \t]+  # Get x
+(?P<y> [\-\+]? (\d*\.\d+|\d+\.?\d*) ([Ee][\+\-]?\d+)? ) [ \t]+  # Get y
+(?P<z> [\-\+]? (\d*\.\d+|\d+\.?\d*) ([Ee][\+\-]?\d+)? )         # Get z
+"""
+
+# MULTILINE and VERBOSE regex to match frames:
+FRAME_MATCH_REGEX = r"""
+                                        # First line contains an integer
+                                        # and only an integer: the number of atoms
+^[ \t]* (?P<natoms> [0-9]+) [ \t]*[\n]  # End first line
+(?P<comment>.*) [\n]                    # The second line is a comment
+(?P<positions>                          # This is the block of positions
+    (
+        (
+            \s*                         # White space in front of the element spec is ok
+            (
+                [A-Za-z]+[A-Za-z0-9]*   # Element spec
+                (
+                   \s+                  # White space in front of the number
+                   [\-\+]?              # Plus or minus in front of the number (optional)
+                   (\d*                 # optional decimal in the beginning .0001 is ok, for example
+                    \.                  # There has to be a dot followed by
+                    \d+)                # at least one decimal
+                    |                   # OR
+                   (\d+                 # at least one decimal, followed by
+                    \.?                 # an optional dot
+                    \d*)                # followed by optional decimals
+                   ([Ee][\+\-]?\d+)?    # optional exponents E+03, e-05
+                ){3}                    # I expect three float values
+                |
+                \#                      # If a line is commented out, that is also ok
+            )
+            .*                          # I do not care what is after the comment or the position spec
+            |                           # OR
+            \s*                         # A line only containing white space
+         )
+        [\n]                            # line break at the end
+    )+
+)                                       # A positions block should be one or more lines
+"""
+
+
+class BlockIterator(Iterator):
+    """Extract atom entries from a matched XYZ frame."""
+
+    def __init__(self, it, natoms):
+        self._it = it
+        self._natoms = natoms
+        self._catom = 0
+
+    def __next__(self):
+        try:
+            match = next(self._it)
+        except StopIteration:
+            if self._catom == self._natoms:
+                raise
+            raise ValueError(
+                f"Number of atom entries {self._catom} is smaller than "
+                f"the number of atoms {self._natoms}"
+            ) from None
+
+        self._catom += 1
+
+        if self._catom > self._natoms:
+            raise TypeError(
+                f"Number of atom entries {self._catom} is larger than "
+                f"the number of atoms {self._natoms}"
+            )
+
+        return (match["sym"], (float(match["x"]), float(match["y"]), float(match["z"])))
+
+
+def parse_iter(fh_or_string):
+    """Yield frame tuples containing atom count, comment, and atom iterator."""
+
+    with as_byteorstringlike(fh_or_string) as (content, is_string):
+        if is_string:
+            frame_match = re.compile(FRAME_MATCH_REGEX, re.MULTILINE | re.VERBOSE)
+            pos_match = re.compile(POS_MATCH_REGEX, re.MULTILINE | re.VERBOSE)
+        else:
+            frame_match = re.compile(
+                FRAME_MATCH_REGEX.encode("utf8"), re.MULTILINE | re.VERBOSE
+            )
+            pos_match = re.compile(
+                POS_MATCH_REGEX.encode("utf8"), re.MULTILINE | re.VERBOSE
+            )
+
+        for block in frame_match.finditer(content):
+            natoms = int(block["natoms"])
+            yield (
+                natoms,
+                block["comment"] if is_string else block["comment"].decode("utf8"),
+                BlockIterator(pos_match.finditer(block["positions"]), natoms),
+            )
+
+
+def parse(fh_or_string):
+    """Return XYZ frames with materialized atom lists."""
+
+    return [
+        {"natoms": natoms, "comment": comment, "atoms": list(atomiter)}
+        for natoms, comment, atomiter in parse_iter(fh_or_string)
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "aiida-gaussian-datatypes",
     "ase",
     "ruamel.yaml>=0.16.5",
-    "cp2k-output-tools",
     "aiida-pseudo~=1.2",
     "upf-to-json>=0.9",
 ]
@@ -36,6 +35,9 @@ name = "The AiiDA team"
 Homepage = "https://github.com/aiidateam/aiida-cp2k"
 
 [project.optional-dependencies]
+output-tools = [
+    "cp2k-output-tools",
+]
 dev = [
     "bumpver==2022.1119",
     "pgtest~=1.3",

--- a/test/test_optional_output_tools.py
+++ b/test/test_optional_output_tools.py
@@ -1,0 +1,32 @@
+###############################################################################
+# Copyright (c), The AiiDA-CP2K authors.                                      #
+# SPDX-License-Identifier: MIT                                                #
+# AiiDA-CP2K is hosted on GitHub at https://github.com/aiidateam/aiida-cp2k   #
+# For further information on the license, see the LICENSE.txt file.           #
+###############################################################################
+"""Test the optional cp2k-output-tools parser dependency."""
+
+import builtins
+
+import pytest
+
+from aiida_cp2k.parsers import Cp2kToolsParser
+
+
+def test_tools_parser_reports_missing_optional_dependency(monkeypatch):
+    """Explain how to install the dependency when its parser is selected."""
+
+    original_import = builtins.__import__
+
+    def import_without_output_tools(name, *args, **kwargs):
+        if name == "cp2k_output_tools":
+            raise ImportError("simulated missing optional dependency")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_output_tools)
+
+    with pytest.raises(
+        ImportError,
+        match=r"Install aiida-cp2k\[output-tools\] to use this parser",
+    ):
+        Cp2kToolsParser._parse_stdout(object())

--- a/test/test_xyz_parser.py
+++ b/test/test_xyz_parser.py
@@ -1,0 +1,108 @@
+###############################################################################
+# Copyright (c), The AiiDA-CP2K authors.                                      #
+# SPDX-License-Identifier: MIT                                                #
+# AiiDA-CP2K is hosted on GitHub at https://github.com/aiidateam/aiida-cp2k   #
+# For further information on the license, see the LICENSE.txt file.           #
+###############################################################################
+"""Test parsing CP2K XYZ trajectories."""
+
+import pytest
+
+from aiida_cp2k.utils.xyz import parse
+
+CP2K_XYZ = """\
+2
+ i = 0, time = 0.000, E = -1.2500000000E+01
+ C1  0.0  1.0  2.0
+ H2 -0.35 +4.0 5.
+2
+ i = 1, time = 0.500, E = -1.3000000000E+01
+ C1  0.1  1.1  2.1
+ H2 -0.4  4.1  5.1
+"""
+
+
+def test_parse_cp2k_xyz():
+    """Parse CP2K frames with kind labels and signed coordinates."""
+
+    frames = parse(CP2K_XYZ)
+
+    assert frames == [
+        {
+            "natoms": 2,
+            "comment": " i = 0, time = 0.000, E = -1.2500000000E+01",
+            "atoms": [("C1", (0.0, 1.0, 2.0)), ("H2", (-0.35, 4.0, 5.0))],
+        },
+        {
+            "natoms": 2,
+            "comment": " i = 1, time = 0.500, E = -1.3000000000E+01",
+            "atoms": [("C1", (0.1, 1.1, 2.1)), ("H2", (-0.4, 4.1, 5.1))],
+        },
+    ]
+
+
+def test_parse_cp2k_xyz_bytes():
+    """Preserve the upstream byte-input behavior."""
+
+    frames = parse(CP2K_XYZ.encode())
+
+    assert frames[0]["comment"] == " i = 0, time = 0.000, E = -1.2500000000E+01"
+    assert frames[0]["atoms"][0][0] == b"C1"
+
+
+def test_parse_cp2k_xyz_file_handles(tmp_path):
+    """Parse text and binary file handles identically."""
+
+    xyz_file = tmp_path / "trajectory.xyz"
+    xyz_file.write_text(CP2K_XYZ)
+
+    with xyz_file.open() as handle:
+        text_frames = parse(handle)
+    with xyz_file.open("rb") as handle:
+        binary_frames = parse(handle)
+
+    assert text_frames == binary_frames
+    assert text_frames[0]["atoms"][0][0] == b"C1"
+
+
+def test_parse_preserves_restart_frames():
+    """Do not silently remove repeated step IDs produced by a restart."""
+
+    restarted = CP2K_XYZ + CP2K_XYZ.replace("i = 0", "i = 1", 1)
+
+    frames = parse(restarted)
+
+    assert len(frames) == 4
+    assert [frame["comment"].split(",")[0].strip() for frame in frames] == [
+        "i = 0",
+        "i = 1",
+        "i = 1",
+        "i = 1",
+    ]
+
+
+def test_parse_rejects_too_few_atoms():
+    """Reject frames with fewer atom records than declared."""
+
+    content = """\
+2
+incomplete frame
+H 0.0 0.0 0.0
+"""
+
+    with pytest.raises(ValueError, match="1 is smaller than the number of atoms 2"):
+        parse(content)
+
+
+def test_parse_rejects_too_many_atoms():
+    """Reject frames with more atom records than declared."""
+
+    content = """\
+1
+overfull frame
+H 0.0 0.0 0.0
+H 1.0 1.0 1.0
+"""
+
+    with pytest.raises(TypeError, match="2 is larger than the number of atoms 1"):
+        parse(content)


### PR DESCRIPTION
## Summary

- vendor the CP2K XYZ trajectory parser used by the base parser
- remove `cp2k-output-tools` from mandatory runtime dependencies
- retain `Cp2kToolsParser` behind the optional `output-tools` extra
- add regression tests for XYZ parsing and the optional-dependency error

## Motivation

The released `cp2k-output-tools` versions constrain NumPy to `<2`. Consequently, installing `aiida-cp2k` in a NumPy 2 environment can make the resolver backtrack to old `cp2k-output-tools` and `regex` releases. The development branch of `cp2k-output-tools` supports NumPy 2, but relying on an unreleased branch does not resolve the mandatory release dependency. This is related to cp2k/cp2k-output-tools#58.

The base parser only needs the small, standard-library XYZ trajectory parser. This PR adapts that parser from cp2k-output-tools commit `403cc70966d7284d9f71f56b8cd2ae08f969fa62`, retaining its MIT attribution. Users who explicitly select `Cp2kToolsParser` can install `aiida-cp2k[output-tools]`.

## Validation

- `pytest -q`: 66 passed with Python 3.12, AiiDA 2.8.0, NumPy 2.5.1, and CP2K 9.1
- pre-commit: Black, Flake8, isort, pyupgrade, and mypy passed
- `pip check`: no broken requirements
- editable package metadata contains `cp2k-output-tools ; extra == "output-tools"` and no unconditional requirement
- all three parser entry points load successfully

Prepared with Codex assistance.
