### PR TITLE
Restore CI on current GitHub runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,39 +21,22 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-
-    # see https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache
-    - name: Cache Docker layers
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
+      uses: docker/setup-buildx-action@v4
 
     - name: Build
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v7
       with:
         context: .
         push: false
         load: true
         tags: aiida_cp2k_test
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new
+        cache-from: type=gha,scope=aiida-${{ matrix.aiida-version }}
+        cache-to: type=gha,mode=max,scope=aiida-${{ matrix.aiida-version }}
         build-args: |
           AIIDA_VERSION=${{ matrix.aiida-version }}
-
-    # Temp fix
-    # https://github.com/docker/build-push-action/issues/252
-    # https://github.com/moby/buildkit/issues/1896
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: Create container from aiida_cp2k_test image and test the plugin inside
       run: |
@@ -70,9 +53,9 @@ jobs:
       matrix:
         python-version: [3.11]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install python dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,9 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v7
         with:
           python-version: '3.8'
       - name: Install flit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
           args: [--profile, black, --filter-files]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
+    rev: v3.21.2
     hooks:
         - id: pyupgrade
           args: [--py37-plus]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,8 +45,10 @@ extensions = [
 ]
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/2.7", None),
-    "aiida": ("http://aiida-core.readthedocs.io/en/latest/", None),
+    "python": ("https://docs.python.org/3", None),
+    # AiiDA 2.7.1 is the latest 2.x inventory that publishes the class targets
+    # required by ``show-inheritance``. Newer inventories omit these API targets.
+    "aiida": ("https://aiida.readthedocs.io/projects/aiida-core/en/v2.7.1/", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
## Summary

- update the GitHub Actions and Docker Buildx actions to supported current majors
- replace the deprecated manual Docker-layer cache with Buildx's native GitHub Actions cache
- update `pyupgrade` to a Python 3.14-compatible release
- repair Python and AiiDA intersphinx inventories so warnings-as-errors documentation builds resolve inheritance links

No tests are removed, skipped, or weakened. The existing AiiDA 2.4.3 and 2.5.1 test matrix is unchanged, and Sphinx still runs with `-nW`.

## Root causes and changes

### GitHub Actions jobs did not start

GitHub rejects `actions/cache@v2` before any test step runs. The workflow also used old Node-based releases of checkout, setup-python, and the Docker actions.

This PR updates:

- `actions/checkout` from v2 to v7
- `actions/setup-python` from v2 to v7
- `docker/setup-buildx-action` from v1 to v4
- `docker/build-push-action` from v2 to v7

The local-directory cache and its explicitly temporary remove/move step are replaced with Buildx's supported `type=gha` backend. Cache scopes include the AiiDA matrix version so the two Docker builds cannot overwrite each other's cache.

The release workflow receives the same checkout/setup-python updates so it does not retain the deprecated runtime path.

### pre-commit.ci crashed in pyupgrade

`pyupgrade` v3.19.1 crashes under the current pre-commit.ci Python 3.14.1 runtime with:

```text
TypeError: cannot use a bytes pattern on a string-like object
```

Upstream first fixed the Python 3.14.1 `tokenize.cookie_re` incompatibility in v3.21.1. This PR uses current stable v3.21.2. Open automated PR #229 independently uses v3.21.2 and its pre-commit.ci check passes, but also contains broad formatter/hook updates; this PR includes only the compatibility change required to restore CI.

### Sphinx could not resolve inheritance targets

The documentation configuration still used the Python 2.7 inventory. It also followed AiiDA `latest`, whose AiiDA 2.8 inventory no longer publishes the API class targets emitted by `show-inheritance`.

This PR uses the Python 3 inventory and the AiiDA 2.7.1 inventory, the latest AiiDA 2.x inventory verified to publish the required `CalcJob`, `Parser`, and `BaseRestartWorkChain` targets. This resolves the references instead of adding them to `nitpick_ignore` or disabling warnings-as-errors. The Python 3 inventory also resolves `collections.abc.Iterator` when this branch is combined with #231.

## Validation

- `pre-commit run --all-files`: all hooks passed
- `actionlint` 1.7.12: both workflows passed
- all changed YAML files parsed successfully
- `make -C docs`: passed with Sphinx 9.1.0 and `-nW`
- isolated combination with #231: documentation and actionlint passed, including `aiida_cp2k.utils.xyz.BlockIterator`
- `pip check`: no broken requirements
- unchanged full local test command: 49 passed; 10 current-`main` trajectory tests fail while importing the old `cp2k-output-tools`/`regex` installation in the NumPy 2 environment. This CI-only branch does not alter that source path. The same full suite passed 66/66 on #231, which addresses that dependency separately.

Prepared with Codex assistance.
